### PR TITLE
Clean up lines and make argument default to the log limit of not present

### DIFF
--- a/src/venti.ts
+++ b/src/venti.ts
@@ -37,10 +37,8 @@ class Venti {
         return ret.substring(0, ret.indexOf('('));
     }
 
-    eventLog(limit: number) {
-        let l = this.eventLogLimit;
-        if(typeof limit !== 'undefined'){ l = limit }
-        return this.log.reverse().splice(0,l);
+    eventLog(limit: number = this.eventLogLimit) {
+        return this.log.reverse().splice(0,limit);
     }
 
     on(str: string, callback: Function) {


### PR DESCRIPTION
I saw that with typescript, we can just have a default argument and it will infer that its optional 

- [x] Make the limit argument optional.
- [x] default to returning this.eventLogLimit events if limit wasn't provided.
- [x] I should expect to see up to the default event log limit if I call Venti.eventLog()
- [x] I should expect to see up to my limit if I call Venti.eventLog(10 // or whatever number you want)

Just a quick question though, in the package.json it says about the main being the `dist/venti.js` but its not in the code? Does that also need to change?